### PR TITLE
Internationalize date format for sessions

### DIFF
--- a/src/pages/sessions.astro
+++ b/src/pages/sessions.astro
@@ -4,13 +4,6 @@ import PageLayout from "../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
 let sessions = await getCollection("sessions");
 sessions = sessions.sort((a, b) => a.date - b.date);
-const getDate = (d: Date) => {
-  const addLeadingZero = (n: number) => (n < 10 ? `0${n}` : n.toString());
-
-  const day = addLeadingZero(d.getUTCDate());
-  const month = addLeadingZero(d.getUTCMonth() + 1);
-  return `${day}/${month}/${d.getUTCFullYear()}`;
-};
 ---
 
 <PageLayout
@@ -37,7 +30,7 @@ const getDate = (d: Date) => {
               <td>
                 <a href={href}>{session.data.title}</a>
               </td>
-              <td>{getDate(session.data.date)}</td>
+              <td>{session.data.date.toLocaleDateString()}</td>
               <td>{session.data.champion}</td>
               <td>{session.data.company}</td>
             </tr>


### PR DESCRIPTION
This will use locale info to format dates to match the user's locale preference. For example the current format is not what I'm used to reading in US, so it takes me a minute to parse in my head each time lol. For example: this change will format the date `July 4 2023` like so:

| Locale | Output | 
| -- | -- |
| `en-US` | `7/4/2023` |
| `en-UK` | `04/07/2023` |

Or, we could get fancy and update the `toLocaleDateString` call like so and do something like this, which I think is even more readable:
```js
date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
```
| Locale | Output | 
| -- | -- |
| `en-US` | `July 4, 2023` |
| `en-UK` | `4 July 2023` |
