### PR TITLE
adding Session Widget to pages: index + sessions

### DIFF
--- a/src/components/SessionWidget.astro
+++ b/src/components/SessionWidget.astro
@@ -1,0 +1,51 @@
+---
+interface Props {
+    title?: string;
+    description?: string;
+    date?: Date;
+    url?: string;
+}
+
+const { title, description, date, url } = Astro.props;
+
+const header =
+    date && date >= new Date() ? "Upcoming Session" : "Previous Session";
+---
+
+<div class="card border p-3 bg-light">
+    <div class="card-body">
+        <h6 class="card-subtitle mb-2 text-muted" id="session-header">
+            {header}
+        </h6>
+        <h5 class="card-title">{title}</h5>
+        <p class="card-text">
+            {description}
+        </p>
+        <h4 class="card-subtitle mb-2 text-muted" id="session-time">
+            {date?.toLocaleDateString()}
+        </h4>
+        {
+            url && (
+                <a href={url} class="card-link">
+                    Read more
+                </a>
+            )
+        }
+    </div>
+</div>
+
+<script is:inline src="https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js"
+></script>
+
+<script define:vars={{ date }}>
+    // updating session-time
+    const currentSessionTime = document.getElementById("session-time");
+    currentSessionTime.innerText += ` - ${moment(date).fromNow()}`;
+    // updating session-header
+    const currentSessionHeader = document.getElementById("session-header");
+    if (moment(date).isAfter(moment())) {
+        currentSessionHeader.innerText = "Upcoming Session";
+    } else {
+        currentSessionHeader.innerText = "Previous Session";
+    }
+</script>


### PR DESCRIPTION
![Screenshot 2023-04-06 at 13 27 50](https://user-images.githubusercontent.com/18899702/230366729-44a0745c-8d25-4ea1-8c42-7a74d7454845.png)

The idea is to add a Session widget (last session), with a dynamic countdown (changes on refresh)

related to issues:
- #21 
- #19 