### PR TITLE
improving image header

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -17,25 +17,23 @@ const { src } = await getImage({
 ---
 
 <Layout {...props}>
-  <header style={{ backgroundImage: `url(${src})` }}>
+  <header style={{ backgroundImage: `url(${src})` }} class="container p-0">
     <div class="inner">
-      <div class="container">
-        <h1>{mainTitle}</h1>
-        {
-          author && (
-            <div id="author">
-              <Image
-                src={author.picture}
-                alt={`Profile picture of ${author.name}`}
-                width={100}
-                height={100}
-                class="img-thumbnail"
-              />
-              <strong>{author.name}</strong>
-            </div>
-          )
-        }
-      </div>
+      <h1 class="ms-4">{mainTitle}</h1>
+      {
+        author && (
+          <div id="author">
+            <Image
+              src={author.picture}
+              alt={`Profile picture of ${author.name}`}
+              width={100}
+              height={100}
+              class="img-thumbnail"
+            />
+            <strong>{author.name}</strong>
+          </div>
+        )
+      }
     </div>
   </header>
   <main class="m-4">


### PR DESCRIPTION
related to #22 
Just a suggestion, not sure that I understand what is expected here.
# Preview
![Screenshot 2023-04-05 at 18 17 59](https://user-images.githubusercontent.com/18899702/230367332-b560b3f3-7a5d-40bb-844b-a38c925170e0.png)
# Preview on larger screen
![Screenshot 2023-04-05 at 18 15 00](https://user-images.githubusercontent.com/18899702/230367322-8ca49717-a56d-4b2d-a2e2-83b75088ae36.png)

