### PR TITLE
Patrick Stevens session: Compiler warning when obj is inferred as a type

### DIFF
--- a/src/content/sessions/2023-06-02.md
+++ b/src/content/sessions/2023-06-02.md
@@ -1,0 +1,39 @@
+---
+title: Compiler warning when obj is inferred as a type
+preview: Compiler warning when obj is inferred as a type
+isDraft: false
+date: 2023-06-02
+slug: "2023/06/02"
+champion: Patrick Stevens
+company: G-Research
+repository: https://github.com/dotnet/fsharp/pull/13298
+---
+
+## Problem
+
+When the F# type-checker infers a type to be obj without annotation it does not warn.
+This can lead to subtle bugs, where the programmer has forgotten to annotate a type, and the code is not doing what they expect.
+We create a compiler warnin that warns when obj is inferred as a type.
+
+```fsharp
+We would warn in the following case, where a is inferred to be obj because that's the most general thing it could be:
+
+let f<'b> () : 'b =
+    let a = failwith ""
+    a |> unbox
+
+The following code should not generate a warning, because a is constrained to be obj by the type argument to unbox, and b is constrained to be obj because it is of the same type as a.
+let a = 5 |> unbox<obj>
+let b = a
+```
+
+## Champion
+
+- Patrick Stevens
+- [approved-suggestion](https://github.com/fsharp/fslang-suggestions/issues/696)
+
+## Links
+
+- Date: June 02, 15:00 (GMT+2:00) Central European Summer Time (<small>or 09:00 (GMT-4:00) Eastern Time</small>)
+- Session link: https://us06web.zoom.us/j/85355770641?pwd=azY1UU9oaHA4dWlPaWlnUE9xQTFBZz09
+- Passcode: 581082

--- a/src/content/sessions/2023-06-02.md
+++ b/src/content/sessions/2023-06-02.md
@@ -13,7 +13,7 @@ repository: https://github.com/dotnet/fsharp/pull/13298
 
 When the F# type-checker infers a type to be obj without annotation it does not warn.
 This can lead to subtle bugs, where the programmer has forgotten to annotate a type, and the code is not doing what they expect.
-We create a compiler warnin that warns when obj is inferred as a type.
+We create a compiler warning that warns when obj is inferred as a type.
 
 ```fsharp
 We would warn in the following case, where a is inferred to be obj because that's the most general thing it could be:


### PR DESCRIPTION
This PR adds a page for the next session.