### PR TITLE
add session page for 2023-10-20

### DIFF
--- a/src/content/sessions/2023-10-20.md
+++ b/src/content/sessions/2023-10-20.md
@@ -1,0 +1,33 @@
+---
+title: "What is new in F# 8"
+preview: ""
+isDraft: true
+date: 2023-10-20T13:00:00.000Z
+slug: "2023/10/20"
+champion: "The F# team"
+zoomLink: "https://us06web.zoom.us/j/83290475889?pwd=nZBQp1bkVCczXXy8Wxf0l5BSbIrzsm.1"
+zoomPasscode: "F#8"
+issueLink: ""
+company: "Microsoft"
+youtubeId: ""
+---
+
+## Topic
+
+The release of .NET 8 is just a few weeks away, meaning version 8 of F# is also just around the corner.  
+In this very special session, the F# team itself will talk about what the .NET world can expect from this release.  
+A lot of great work from the team members and the community has been done to make this the best version of F# to date:  
+
+* New language features
+* Performance improvements
+* Better tooling support
+
+Let's have a tour of what's to come from the very heart of F#.
+
+## Champions
+
+- [Adam Boniecki](https://github.com/abonie)
+- [Petr Pokorny](https://github.com/0101)
+- [Petr Semkin](https://github.com/psfinaki)
+- [Tomas Grosup](https://github.com/T-Gro)
+- [Vlad Zarytovskii](https://github.com/vzarytovskii)


### PR DESCRIPTION
This PR adds the session page for the F# 8 session on 2023-10-20.

@abonie, @0101, @psfinaki, @T-Gro, @vzarytovskii Please take a look and let us know if we should change something or if we can go public with it.
